### PR TITLE
more safeguards 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+__pycache__


### PR DESCRIPTION
- cli arg --allow-code chack
- add in UI Warring

---

cli arg `--allow-code` is used as a savfy check in webui in the built-in custom_code script code execution
see https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/b7f45e67dcf48914d2f34d4ace977a431a5aa12e/scripts/custom_code.py#L64

I think it's better that this also follows the the same check

if `--allow-code` is not used, then it will just output a message
```py
Command Line Arg --allow-code must be enabled.
```

---

also I added warning markdown in the UI
the usere can remove the warning message in settings

### screenshots
![image](https://github.com/SenshiSentou/sd-webui-qic-console/assets/40751091/99eca715-5b5e-4938-a05b-359d98f336a3)
![image](https://github.com/SenshiSentou/sd-webui-qic-console/assets/40751091/c5e7d531-63b3-4503-85a9-6ab02a0b6821)